### PR TITLE
fixed error in findMaTemps regarding scalar inputs

### DIFF
--- a/me140_project2/findMaTemps.m
+++ b/me140_project2/findMaTemps.m
@@ -27,19 +27,20 @@ while abs(T0-T0guess)>error;
     assume(M, 'real');
     assumeAlso(M < 1); %Select the subsonic solution. Set M > 1 if want supersonic solution.
     Ma = vpasolve( MFP == M.*sqrt(k).*(1+((k-1)./2).*M.^2).^(-(k+1)./(2.*(k-1))), M );
+    Ma = struct(Ma);
     Ma = struct2array(Ma); %Ma is returned as a symbolic variable which doesn't work in polyval in sp_heats
 
     % (d) Find T via Eq (3)
-    T = Tm/(1+RF*((k-1)/2)*Ma^2);
+    T = Tm./(1+RF.*((k-1)./2).*Ma.^2);
 
     % (e) Find T0 via Eq. (4), If T0 = T0(initial guess) then T0 is correct.
-    T0 = T*(1+((k-1)/2)*Ma^2);
+    T0 = T.*(1+((k-1)./2).*Ma.^2);
 
     % update
     T0guess = T0;
     k = sp_heats(T); 
 end
 
-U = Ma*sqrt(k*R*T0);
+U = Ma.*sqrt(k.*R.*T0);
 end
 

--- a/me140_project2/findMaTemps.m~
+++ b/me140_project2/findMaTemps.m~
@@ -18,26 +18,29 @@ k = sp_heats(T0guess);
 
 while abs(T0-T0guess)>error;
     % (b) Find MFP via Eq. (1)
-    MFP = (mdot/A)*sqrt(R*T0guess)/P0;
+    MFP = (mdot./A).*sqrt(R.*T0guess)./P0;
 
     % (c) Determine Ma that satisfies Eq. (2)
-    M = sym('a',[length(MFP),1]);
+    % Solve coded to work with a matrix of MFP entered. Not tested with
+    % matrix of k values.
+    M = sym('m',[length(MFP),1]);
     assume(M, 'real');
     assumeAlso(M < 1); %Select the subsonic solution. Set M > 1 if want supersonic solution.
     Ma = vpasolve( MFP == M.*sqrt(k).*(1+((k-1)./2).*M.^2).^(-(k+1)./(2.*(k-1))), M );
-    Ma = struct2cell(Ma); %Ma is returned as a symbolic variable which doesn't work in polyval in sp_heats
-    
+    Ma = struct(Ma);
+    Ma = struct2array(Ma); %Ma is returned as a symbolic variable which doesn't work in polyval in sp_heats
+
     % (d) Find T via Eq (3)
-    T = Tm/(1+RF*((k-1)/2)*Ma^2);
+    T = Tm./(1+RF.*((k-1)./2).*Ma.^2);
 
     % (e) Find T0 via Eq. (4), If T0 = T0(initial guess) then T0 is correct.
-    T0 = T*(1+((k-1)/2)*Ma^2);
+    T0 = T.*(1+((k-1)./2).*Ma.^2);
 
     % update
     T0guess = T0;
     k = sp_heats(T); 
 end
 
-U = Ma*sqrt(k*R*T0);
+U = Ma.*sqrt(k.*R.*T0);
 end
 


### PR DESCRIPTION
Fixed an error where solve, working for matrix inputs, had stopped
working for scalar inputs. Now works for both. all input parameters can
now be passed in as matrices. Inputs should be entered as column
vectors with row 1 of each input matrix corresponding to the first
state, row two of each input corresponding to all the inputs
representing the second state, etc. By column vector I mean [1;2;3]